### PR TITLE
fix: pointer switch jump on ACTION_POINTER_UP

### DIFF
--- a/zoomimage-view/src/main/kotlin/com/github/panpf/zoomimage/view/zoom/internal/ScaleDragGestureDetector.kt
+++ b/zoomimage-view/src/main/kotlin/com/github/panpf/zoomimage/view/zoom/internal/ScaleDragGestureDetector.kt
@@ -49,6 +49,7 @@ internal class ScaleDragGestureDetector(
     private var canDragged = true
     private var lastGestureFocus: OffsetCompat? = null
     private var pointCount = 0
+    private var lastPointCount = 0
     private var scaleFactor: Float? = null
 
     init {
@@ -103,16 +104,22 @@ internal class ScaleDragGestureDetector(
                 firstTouch = null
                 lastGestureFocus = null
                 scaleFactor = null
+                lastPointCount = 0
                 scaleDetector.onTouchEvent(ev)
             }
 
             MotionEvent.ACTION_MOVE -> {
                 scaleDetector.onTouchEvent(ev)
+                
+                // Detect pointer count change (e.g., 2->1 or 1->2)
+                val pointCountChanged = (pointCount != lastPointCount)
+                lastPointCount = pointCount
+                
                 if (pointCount > 1) {
                     val scaleFactor = this@ScaleDragGestureDetector.scaleFactor ?: 1f
                     val scaleFocus = OffsetCompat(scaleDetector.focusX, scaleDetector.focusY)
                     val lastGestureFocus = lastGestureFocus
-                    val panChange = if (lastGestureFocus != null)
+                    val panChange = if (lastGestureFocus != null && !pointCountChanged)
                         scaleFocus - lastGestureFocus else OffsetCompat.Zero
                     onGestureListener.onGesture(
                         scaleFactor = scaleFactor,
@@ -126,7 +133,13 @@ internal class ScaleDragGestureDetector(
                     // Avoid changing from two fingers to one finger, lastTouchX and lastTouchY mutations, causing the image to pan instantly
                     val firstTouch = firstTouch
                     val lastTouch = lastTouch
-                    if (firstTouch != null && lastTouch != null) {
+                    
+                    // Reset baseline on pointer count change to avoid using stale coordinates
+                    if (pointCountChanged) {
+                        this@ScaleDragGestureDetector.firstTouch = touch
+                        this@ScaleDragGestureDetector.lastTouch = touch
+                        this@ScaleDragGestureDetector.lastGestureFocus = touch
+                    } else if (firstTouch != null && lastTouch != null) {
                         if (!isDragging) {
                             val d = touch - firstTouch
                             val dx = d.x


### PR DESCRIPTION
## Summary

Fixes one-frame jump when releasing one finger during pinch zoom.

## Problem

When performing a pinch zoom and releasing one finger (pointer transition from 2 to 1), the image center appears to "jump" for one frame. This issue is device-dependent and more visible on certain OEM devices with specific touch sampling rates and motion event batching strategies.

## Root Cause

When `ACTION_POINTER_UP` switches `activePointerId`, the first `ACTION_MOVE` frame uses stale `lastTouch` coordinates from the two-finger phase to calculate `panChange`, causing a one-frame jump in the pan delta.

## Solution

- Added `lastPointCount` tracking to detect pointer count changes (e.g., 2→1 or 1→2)
- On first frame after pointer count change:
  - Reset drag baselines (`firstTouch`, `lastTouch`, `lastGestureFocus`)
  - Zero out `panChange` to prevent the jump
- This ensures clean state transition between single-finger and multi-finger gesture phases

## Changes

**File modified:** `zoomimage-view/src/main/kotlin/com/github/panpf/zoomimage/view/zoom/internal/ScaleDragGestureDetector.kt`

Key changes:
1. Added `lastPointCount` field to track pointer count transitions
2. Detect `pointCountChanged` in `ACTION_MOVE`
3. On transition: reset baselines and zero `panChange`

## Testing

- ✅ Two-finger zoom → release one finger while still moving
- ✅ One-finger drag → add second finger to zoom
- ✅ Zoom past bounds → release → rollback center check
- ✅ No regression in fling/rollback behavior
- ✅ ViewPager interception behavior unchanged

## Related Issues

This is related to the pointer-count transition handling that was previously addressed in issue #12 (fixed in v1.0.1), and later architectural changes in commit `605b4ac1` ("supports two-finger drag gestures") touched the same detector area.